### PR TITLE
Add missing main()

### DIFF
--- a/src/cdiff.py
+++ b/src/cdiff.py
@@ -541,7 +541,7 @@ def main():
             sys.stderr.write(('*** Not in a supported workspace, supported '
                               'are: %s\n\n') % ', '.join(supported_vcs))
             parser.print_help()
-            return 1
+            sys.exit(1)
     else:
         diff_hdl = sys.stdin
 
@@ -550,7 +550,7 @@ def main():
 
     # Don't let empty diff pass thru
     if not stream:
-        return 0
+        return
 
     if diff_hdl is not sys.stdin:
         diff_hdl.close()
@@ -568,6 +568,6 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()
 
 # vim:set et sts=4 sw=4 tw=80:


### PR DESCRIPTION
Previously, "console_scripts" in "setup.py" was pointing to a non-existent main(). This would result in the following error:

``` shell

$ cdiff
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/pkg_resources.py", line 2017, in load
    entry = getattr(entry,attr)
AttributeError: 'module' object has no attribute 'main'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/myint/Library/Python/3.3/bin/cdiff", line 9, in <module>
    load_entry_point('cdiff==0.0.1', 'console_scripts', 'cdiff')()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/pkg_resources.py", line 343, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/pkg_resources.py", line 2308, in load_entry_point
    return ep.load()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/site-packages/pkg_resources.py", line 2019, in load
    raise ImportError("%r has no %r attribute" % (entry,attr))
ImportError: <module 'cdiff' from '/Users/myint/Library/Python/3.3/bin/cdiff.py'> has no 'main' attribute
```
