### PR TITLE
Add Travis CI test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
     - python setup.py install
 
 script:
-    ./tests/tests.sh
+    - ./tests/tests.sh


### PR DESCRIPTION
I noticed you added several automated tests. So this pull request may be useful to you.

This will run the tests on CPython (2.5 through 3.3) and PyPy. Once you activate your Travis CI account, each push to this repository will automatically trigger a test run on the Travis CI server. See an example test run [here](https://travis-ci.org/myint/cdiff).

Note that you can add a badge to the readme to reflect the test status. See the top of [this page](https://github.com/myint/autoflake/blob/master/README.rst) for an example.
