### PR TITLE
Handle keyboard interrupt gracefully

### DIFF
--- a/cdiff.py
+++ b/cdiff.py
@@ -536,8 +536,11 @@ def markup_to_pager(stream, opts):
     # args stolen fron git source: github.com/git/git/blob/master/pager.c
     pager = subprocess.Popen(['less', '-FRSX'],
             stdin=subprocess.PIPE, stdout=sys.stdout)
-    for line in color_diff:
-        pager.stdin.write(line.encode('utf-8'))
+    try:
+        for line in color_diff:
+            pager.stdin.write(line.encode('utf-8'))
+    except KeyboardInterrupt:
+        pass
 
     pager.stdin.close()
     pager.wait()


### PR DESCRIPTION
Previously, a keyboard interrupt would result in a corrupted terminal. This would manifest when doing "cdiff --log" on somewhat large repositories.
