### PR TITLE
Temporarily unset GIT_EXTERNAL_DIFF when invoking git diff.

### DIFF
--- a/cdiff.py
+++ b/cdiff.py
@@ -54,7 +54,7 @@ COLORS = {
 VCS_INFO = {
     'Git': {
         'probe' : ['git', 'rev-parse'],
-        'diff'  : ['git', 'diff'],
+        'diff'  : ['env', '-u', 'GIT_EXTERNAL_DIFF', 'git', 'diff'],
         'log'   : ['git', 'log', '--patch'],
     },
     'Mercurial': {


### PR DESCRIPTION
When the git diff command is customized through setting GIT_EXTERNAL_DIFF in the environment, the output of cdiff is broken and defaults to the output of the tool git has been configured to use.

Temporarily unsetting this variable when cdiff invokes git diff fixes the issue.
