### PR TITLE
Handle Latin-1 encoded text in diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.*.swp
 *.pyc
 *~
 *.tmp
 /.coverage
+/.travis-solo/
 /htmlcov/
 /MANIFEST
 /build/

--- a/tests/latin1/in.diff
+++ b/tests/latin1/in.diff
@@ -1,0 +1,9 @@
+diff --git a/test/latin1.cc b/test/latin1.cc
+index a556e5c..d81bb0c 100644
+--- a/test/latin1.cc
++++ b/test/latin1.cc
+@@ -1,4 +1,3 @@
+-// é
+ int latin1()
+ {
+ 	static int x;

--- a/tests/latin1/out.normal
+++ b/tests/latin1/out.normal
@@ -1,0 +1,10 @@
+[36mdiff --git a/test/latin1.cc b/test/latin1.cc
+[0m[36mindex a556e5c..d81bb0c 100644
+[0m[33m--- a/test/latin1.cc
+[0m[33m+++ b/test/latin1.cc
+[0m[1;34m@@ -1,4 +1,3 @@
+[0m[1;31m-// é
+[0m[0m int latin1()
+[0m[0m {
+[0m[0m 	static int x;
+[0m

--- a/tests/latin1/out.side-by-side
+++ b/tests/latin1/out.side-by-side
@@ -1,0 +1,9 @@
+[36mdiff --git a/test/latin1.cc b/test/latin1.cc
+[0m[36mindex a556e5c..d81bb0c 100644
+[0m[33m--- a/test/latin1.cc
+[0m[33m+++ b/test/latin1.cc
+[0m[1;34m@@ -1,4 +1,3 @@
+[0m[33m1[0m [1;31m// é[0m [0m[33m [0m 
+[33m2[0m [0mint latin1()[0m                                                                     [0m[33m1[0m [0mint latin1()[0m
+[33m3[0m [0m{[0m                                                                                [0m[33m2[0m [0m{[0m
+[33m4[0m [0m        static int x;[0m                                                            [0m[33m3[0m [0m        static int x;[0m

--- a/tests/latin1/out.w70
+++ b/tests/latin1/out.w70
@@ -1,0 +1,9 @@
+[36mdiff --git a/test/latin1.cc b/test/latin1.cc
+[0m[36mindex a556e5c..d81bb0c 100644
+[0m[33m--- a/test/latin1.cc
+[0m[33m+++ b/test/latin1.cc
+[0m[1;34m@@ -1,4 +1,3 @@
+[0m[33m1[0m [1;31m// é[0m [0m[33m [0m 
+[33m2[0m [0mint latin1()[0m                                                           [0m[33m1[0m [0mint latin1()[0m
+[33m3[0m [0m{[0m                                                                      [0m[33m2[0m [0m{[0m
+[33m4[0m [0m        static int x;[0m                                                  [0m[33m3[0m [0m        static int x;[0m

--- a/tests/test_cdiff.py
+++ b/tests/test_cdiff.py
@@ -77,9 +77,13 @@ class DecodeTest(unittest.TestCase):
         utext = 'hello'.encode('utf-8')
         self.assertEqual('hello', cdiff.decode(utext))
 
-    def test_malformed_utf8(self):
+    def test_latin_1(self):
         text = '\x80\x02q\x01(U'
-        self.assertEqual(text, cdiff.decode(text))
+        if sys.version_info[0] == 2:
+            decoded_text = text.decode('latin-1')
+        else:
+            decoded_text = text
+        self.assertEqual(decoded_text, cdiff.decode(text))
 
 
 class HunkTest(unittest.TestCase):


### PR DESCRIPTION
This is useful for avoiding crashing on "cdiff -l" (on Python 3) in https://github.com/myint/cppclean.
