### PR TITLE
Use correct integer division

### DIFF
--- a/cdiff.py
+++ b/cdiff.py
@@ -508,7 +508,7 @@ class DiffMarker(object):
                 # [terminal size minus the line number columns and 3 separating
                 # spaces
                 #
-                width = (terminal_size()[0] - num_width * 2 - 3) / 2
+                width = (terminal_size()[0] - num_width * 2 - 3) // 2
             except Exception:
                 # If terminal detection failed, set back to default
                 width = 80


### PR DESCRIPTION
Without this, we get the following on Python 3:

```
return '%s%*s' % (markup_fn(text), pad_len, '')
TypeError: * wants int
```

This bug was introduced by 6befc2a7bf36fbe4fd6c1e702f31599e29bb3f1f.
