### PR TITLE
Fix tab expansion

### DIFF
--- a/tests/diff-of-diff/out.side-by-side
+++ b/tests/diff-of-diff/out.side-by-side
@@ -3,25 +3,25 @@
 [0m[33m--- patch-Alias.xs	(revision 384635)
 [0m[33m+++ patch-Alias.xs	(revision 384636)
 [0m[1;34m@@ -140,17 +140,21 @@
-[0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m                                                [0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m
-[33m141[0m [0m         if (inside)[0m                                                             [0m[33m141[0m [0m         if (inside)[0m
-[33m142[0m [0m                 op_null(tmp);[0m                                                   [0m[33m142[0m [0m                 op_null(tmp);[0m
+[0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m                                                 [0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m
+[33m141[0m [0m        if (inside)[0m                                                              [0m[33m141[0m [0m        if (inside)[0m
+[33m142[0m [0m                op_null(tmp);[0m                                                    [0m[33m142[0m [0m                op_null(tmp);[0m
 [33m143[0m [31m@@ -2001,6 +2035,[4m[31m9[0m[31m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m                   [0m[33m143[0m [32m@@ -2001,6 +2035,[4m[32m13[0m[32m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m144[0m [0m         while (kid->op_sibling != last)[0m                                         [0m[33m144[0m [0m         while (kid->op_sibling != last)[0m
-[33m145[0m [0m                 kid = kid->op_sibling;[0m                                          [0m[33m145[0m [0m                 kid = kid->op_sibling;[0m
-[33m146[0m [0m         kid->op_sibling = Nullop;[0m                                               [0m[33m146[0m [0m         kid->op_sibling = Nullop;[0m
+[33m144[0m [0m        while (kid->op_sibling != last)[0m                                          [0m[33m144[0m [0m        while (kid->op_sibling != last)[0m
+[33m145[0m [0m                kid = kid->op_sibling;[0m                                           [0m[33m145[0m [0m                kid = kid->op_sibling;[0m
+[33m146[0m [0m        kid->op_sibling = Nullop;[0m                                                [0m[33m146[0m [0m        kid->op_sibling = Nullop;[0m
 [33m147[0m [0m+#ifdef op_sibling_splice[0m                                                        [0m[33m147[0m [0m+#ifdef op_sibling_splice[0m
 [33m   [0m                                                                                  [0m[33m148[0m [32m+#if (PERL_COMBI_VERSION >= 5021011)[0m
-[33m   [0m                                                                                  [0m[33m149[0m [32m+        kid->op_moresib = 0;[0m
+[33m   [0m                                                                                  [0m[33m149[0m [32m+       kid->op_moresib = 0;[0m
 [33m   [0m                                                                                  [0m[33m150[0m [32m+#else[0m
-[33m148[0m [0m+        kid->op_lastsib = 1;[0m                                                    [0m[33m151[0m [0m+        kid->op_lastsib = 1;[0m
+[33m148[0m [0m+       kid->op_lastsib = 1;[0m                                                     [0m[33m151[0m [0m+       kid->op_lastsib = 1;[0m
 [33m   [0m                                                                                  [0m[33m152[0m [32m+#endif[0m
 [33m149[0m [0m+#endif[0m                                                                          [0m[33m153[0m [0m+#endif[0m
-[33m150[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                              [0m[33m154[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
-[33m151[0m [0m         if (kid->op_type == OP_NULL && inside)[0m                                  [0m[33m155[0m [0m         if (kid->op_type == OP_NULL && inside)[0m
-[33m152[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m                                  [0m[33m156[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m
+[33m150[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                               [0m[33m154[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
+[33m151[0m [0m        if (kid->op_type == OP_NULL && inside)[0m                                   [0m[33m155[0m [0m        if (kid->op_type == OP_NULL && inside)[0m
+[33m152[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m                                   [0m[33m156[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m
 [33m153[0m [31m@@ -2008,6 +204[4m[31m5[0m[31m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m                  [0m[33m157[0m [32m@@ -2008,6 +204[4m[32m9[0m[32m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m154[0m [0m         return o;[0m                                                               [0m[33m158[0m [0m         return o;[0m
+[33m154[0m [0m        return o;[0m                                                                [0m[33m158[0m [0m        return o;[0m
 [33m155[0m [0m }[0m                                                                               [0m[33m159[0m [0m }[0m
 [33m156[0m [0m [0m                                                                                [0m[33m160[0m [0m [0m
 [1;34m@@ -165,7 +169,7 @@
@@ -29,6 +29,6 @@
 [33m166[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m                                     [0m[33m170[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m
 [33m167[0m [0m [0m                                                                                [0m[33m171[0m [0m [0m
 [33m168[0m [31m@@ -2025,6 +207[4m[31m0[0m[31m,10 @@ BOOT:[0m                                                     [0m[33m172[0m [32m@@ -2025,6 +207[4m[32m4[0m[32m,10 @@ BOOT:[0m
-[33m169[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                               [0m[33m173[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
-[33m170[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m                     [0m[33m174[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
-[33m171[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m                         [0m[33m175[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m
+[33m169[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                                [0m[33m173[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
+[33m170[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m                      [0m[33m174[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
+[33m171[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m                          [0m[33m175[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m

--- a/tests/diff-of-diff/out.w70
+++ b/tests/diff-of-diff/out.w70
@@ -3,25 +3,25 @@
 [0m[33m--- patch-Alias.xs	(revision 384635)
 [0m[33m+++ patch-Alias.xs	(revision 384636)
 [0m[1;34m@@ -140,17 +140,21 @@
-[0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m                                      [0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m
-[33m141[0m [0m         if (inside)[0m                                                   [0m[33m141[0m [0m         if (inside)[0m
-[33m142[0m [0m                 op_null(tmp);[0m                                         [0m[33m142[0m [0m                 op_null(tmp);[0m
+[0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m                                       [0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m
+[33m141[0m [0m        if (inside)[0m                                                    [0m[33m141[0m [0m        if (inside)[0m
+[33m142[0m [0m                op_null(tmp);[0m                                          [0m[33m142[0m [0m                op_null(tmp);[0m
 [33m143[0m [31m@@ -2001,6 +2035,[4m[31m9[0m[31m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m         [0m[33m143[0m [32m@@ -2001,6 +2035,[4m[32m13[0m[32m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m144[0m [0m         while (kid->op_sibling != last)[0m                               [0m[33m144[0m [0m         while (kid->op_sibling != last)[0m
-[33m145[0m [0m                 kid = kid->op_sibling;[0m                                [0m[33m145[0m [0m                 kid = kid->op_sibling;[0m
-[33m146[0m [0m         kid->op_sibling = Nullop;[0m                                     [0m[33m146[0m [0m         kid->op_sibling = Nullop;[0m
+[33m144[0m [0m        while (kid->op_sibling != last)[0m                                [0m[33m144[0m [0m        while (kid->op_sibling != last)[0m
+[33m145[0m [0m                kid = kid->op_sibling;[0m                                 [0m[33m145[0m [0m                kid = kid->op_sibling;[0m
+[33m146[0m [0m        kid->op_sibling = Nullop;[0m                                      [0m[33m146[0m [0m        kid->op_sibling = Nullop;[0m
 [33m147[0m [0m+#ifdef op_sibling_splice[0m                                              [0m[33m147[0m [0m+#ifdef op_sibling_splice[0m
 [33m   [0m                                                                        [0m[33m148[0m [32m+#if (PERL_COMBI_VERSION >= 5021011)[0m
-[33m   [0m                                                                        [0m[33m149[0m [32m+        kid->op_moresib = 0;[0m
+[33m   [0m                                                                        [0m[33m149[0m [32m+       kid->op_moresib = 0;[0m
 [33m   [0m                                                                        [0m[33m150[0m [32m+#else[0m
-[33m148[0m [0m+        kid->op_lastsib = 1;[0m                                          [0m[33m151[0m [0m+        kid->op_lastsib = 1;[0m
+[33m148[0m [0m+       kid->op_lastsib = 1;[0m                                           [0m[33m151[0m [0m+       kid->op_lastsib = 1;[0m
 [33m   [0m                                                                        [0m[33m152[0m [32m+#endif[0m
 [33m149[0m [0m+#endif[0m                                                                [0m[33m153[0m [0m+#endif[0m
-[33m150[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                    [0m[33m154[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
-[33m151[0m [0m         if (kid->op_type == OP_NULL && inside)[0m                        [0m[33m155[0m [0m         if (kid->op_type == OP_NULL && inside)[0m
-[33m152[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m                        [0m[33m156[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m
+[33m150[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                     [0m[33m154[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
+[33m151[0m [0m        if (kid->op_type == OP_NULL && inside)[0m                         [0m[33m155[0m [0m        if (kid->op_type == OP_NULL && inside)[0m
+[33m152[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m                         [0m[33m156[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m
 [33m153[0m [31m@@ -2008,6 +204[4m[31m5[0m[31m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m        [0m[33m157[0m [32m@@ -2008,6 +204[4m[32m9[0m[32m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m154[0m [0m         return o;[0m                                                     [0m[33m158[0m [0m         return o;[0m
+[33m154[0m [0m        return o;[0m                                                      [0m[33m158[0m [0m        return o;[0m
 [33m155[0m [0m }[0m                                                                     [0m[33m159[0m [0m }[0m
 [33m156[0m [0m [0m                                                                      [0m[33m160[0m [0m [0m
 [1;34m@@ -165,7 +169,7 @@
@@ -29,6 +29,6 @@
 [33m166[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m                           [0m[33m170[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m
 [33m167[0m [0m [0m                                                                      [0m[33m171[0m [0m [0m
 [33m168[0m [31m@@ -2025,6 +207[4m[31m0[0m[31m,10 @@ BOOT:[0m                                           [0m[33m172[0m [32m@@ -2025,6 +207[4m[32m4[0m[32m,10 @@ BOOT:[0m
-[33m169[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                     [0m[33m173[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
-[33m170[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m           [0m[33m174[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
-[33m171[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m               [0m[33m175[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m
+[33m169[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                      [0m[33m173[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
+[33m170[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m            [0m[33m174[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
+[33m171[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m                [0m[33m175[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m

--- a/tests/diff-of-diff/out.w70.wrap
+++ b/tests/diff-of-diff/out.w70.wrap
@@ -3,25 +3,25 @@
 [0m[33m--- patch-Alias.xs	(revision 384635)
 [0m[33m+++ patch-Alias.xs	(revision 384636)
 [0m[1;34m@@ -140,17 +140,21 @@
-[0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m                                      [0m[33m140[0m [0m         tmp = kLISTOP->op_first;[0m
-[33m141[0m [0m         if (inside)[0m                                                   [0m[33m141[0m [0m         if (inside)[0m
-[33m142[0m [0m                 op_null(tmp);[0m                                         [0m[33m142[0m [0m                 op_null(tmp);[0m
+[0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m                                       [0m[33m140[0m [0m        tmp = kLISTOP->op_first;[0m
+[33m141[0m [0m        if (inside)[0m                                                    [0m[33m141[0m [0m        if (inside)[0m
+[33m142[0m [0m                op_null(tmp);[0m                                          [0m[33m142[0m [0m                op_null(tmp);[0m
 [33m143[0m [31m@@ -2001,6 +2035,[4m[31m9[0m[31m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m         [0m[33m143[0m [32m@@ -2001,6 +2035,[4m[32m13[0m[32m @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m144[0m [0m         while (kid->op_sibling != last)[0m                               [0m[33m144[0m [0m         while (kid->op_sibling != last)[0m
-[33m145[0m [0m                 kid = kid->op_sibling;[0m                                [0m[33m145[0m [0m                 kid = kid->op_sibling;[0m
-[33m146[0m [0m         kid->op_sibling = Nullop;[0m                                     [0m[33m146[0m [0m         kid->op_sibling = Nullop;[0m
+[33m144[0m [0m        while (kid->op_sibling != last)[0m                                [0m[33m144[0m [0m        while (kid->op_sibling != last)[0m
+[33m145[0m [0m                kid = kid->op_sibling;[0m                                 [0m[33m145[0m [0m                kid = kid->op_sibling;[0m
+[33m146[0m [0m        kid->op_sibling = Nullop;[0m                                      [0m[33m146[0m [0m        kid->op_sibling = Nullop;[0m
 [33m147[0m [0m+#ifdef op_sibling_splice[0m                                              [0m[33m147[0m [0m+#ifdef op_sibling_splice[0m
 [33m   [0m                                                                        [0m[33m148[0m [32m+#if (PERL_COMBI_VERSION >= 5021011)[0m
-[33m   [0m                                                                        [0m[33m149[0m [32m+        kid->op_moresib = 0;[0m
+[33m   [0m                                                                        [0m[33m149[0m [32m+       kid->op_moresib = 0;[0m
 [33m   [0m                                                                        [0m[33m150[0m [32m+#else[0m
-[33m148[0m [0m+        kid->op_lastsib = 1;[0m                                          [0m[33m151[0m [0m+        kid->op_lastsib = 1;[0m
+[33m148[0m [0m+       kid->op_lastsib = 1;[0m                                           [0m[33m151[0m [0m+       kid->op_lastsib = 1;[0m
 [33m   [0m                                                                        [0m[33m152[0m [32m+#endif[0m
 [33m149[0m [0m+#endif[0m                                                                [0m[33m153[0m [0m+#endif[0m
-[33m150[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                    [0m[33m154[0m [0m         cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
-[33m151[0m [0m         if (kid->op_type == OP_NULL && inside)[0m                        [0m[33m155[0m [0m         if (kid->op_type == OP_NULL && inside)[0m
-[33m152[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m                        [0m[33m156[0m [0m                 kid->op_flags &= ~OPf_SPECIAL;[0m
+[33m150[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m                     [0m[33m154[0m [0m        cLISTOPx(cUNOPo->op_first)->op_last = kid;[0m
+[33m151[0m [0m        if (kid->op_type == OP_NULL && inside)[0m                         [0m[33m155[0m [0m        if (kid->op_type == OP_NULL && inside)[0m
+[33m152[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m                         [0m[33m156[0m [0m                kid->op_flags &= ~OPf_SPECIAL;[0m
 [33m153[0m [31m@@ -2008,6 +204[4m[31m5[0m[31m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m        [0m[33m157[0m [32m@@ -2008,6 +204[4m[32m9[0m[32m,14 @@ STATIC OP *da_ck_entersub(pTHX_ OP *o) {[0m
-[33m154[0m [0m         return o;[0m                                                     [0m[33m158[0m [0m         return o;[0m
+[33m154[0m [0m        return o;[0m                                                      [0m[33m158[0m [0m        return o;[0m
 [33m155[0m [0m }[0m                                                                     [0m[33m159[0m [0m }[0m
 [33m156[0m [0m [0m                                                                      [0m[33m160[0m [0m [0m
 [1;34m@@ -165,7 +169,7 @@
@@ -29,6 +29,6 @@
 [33m166[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m                           [0m[33m170[0m [0m MODULE = Data::Alias  PACKAGE = Data::Alias[0m
 [33m167[0m [0m [0m                                                                      [0m[33m171[0m [0m [0m
 [33m168[0m [31m@@ -2025,6 +207[4m[31m0[0m[31m,10 @@ BOOT:[0m                                           [0m[33m172[0m [32m@@ -2025,6 +207[4m[32m4[0m[32m,10 @@ BOOT:[0m
-[33m169[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                     [0m[33m173[0m [0m                 PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
-[33m170[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m           [0m[33m174[0m [0m                 da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
-[33m171[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m               [0m[33m175[0m [0m                 PL_check[OP_ENTERSUB] = da_ck_entersub;[0m
+[33m169[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m                      [0m[33m173[0m [0m                PL_check[OP_RV2CV] = da_ck_rv2cv;[0m
+[33m170[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m            [0m[33m174[0m [0m                da_old_ck_entersub = PL_check[OP_ENTERSUB];[0m
+[33m171[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m                [0m[33m175[0m [0m                PL_check[OP_ENTERSUB] = da_ck_entersub;[0m

--- a/ydiff.py
+++ b/ydiff.py
@@ -540,8 +540,18 @@ class DiffMarker(object):
         """Returns a generator"""
 
         def _normalize(line):
+            index = 0
+            while True:
+                index = line.find('\t', index)
+                if (index == -1):
+                    break
+                # ignore special codes
+                offset = (line.count('\x00', 0, index) * 2 +
+                          line.count('\x01', 0, index))
+                # next stop modulo tab width
+                width = self._tab_width - (index - offset) % self._tab_width
+                line = line[:index] + ' ' * width + line[(index + 1):]
             return (line
-                    .replace('\t', ' ' * self._tab_width)
                     .replace('\n', '')
                     .replace('\r', ''))
 


### PR DESCRIPTION
Expand tab characters to the next stop modulo tab width, instead of using always tab width.
Closes #94.