### PR TITLE
perf: make ~2x faster by killing the hot loop

### DIFF
--- a/ydiff.py
+++ b/ydiff.py
@@ -119,9 +119,9 @@ def strsplit(text, width):
     appended with the resetting sequence, and the second string is prefixed
     with all active colors.
     """
-    first = ''
-    second = ''
-    found_colors = []
+    first = ""
+    second = ""
+    found_colors = ""
     chars_cnt = 0
     bytes_cnt = 0
     while text:
@@ -154,9 +154,7 @@ def strsplit(text, width):
     # If the first string has some active colors at the splitting point,
     # reset it and append the same colors to the second string
     if found_colors:
-        first += COLORS['reset']
-        for color in found_colors:
-            second = COLORS[color] + second
+        return first + COLORS['reset'], found_colors + second, chars_cnt
 
     return (first, second, chars_cnt)
 

--- a/ydiff.py
+++ b/ydiff.py
@@ -125,17 +125,16 @@ def strsplit(text, width):
     chars_cnt = 0
     bytes_cnt = 0
     while text:
-        # First of all, check if current string begins with any escape
-        # sequence.
         append_len = 0
-        for color in COLORS:
-            if text.startswith(COLORS[color]):
-                if color == 'reset':
-                    found_colors = []
+        if text[0] == "\x1b":
+            color_end = text.find("m")
+            if color_end != -1:
+                color = text[:color_end+1]
+                if color == COLORS["reset"]:
+                    found_colors = ""
                 else:
-                    found_colors.append(color)
-                append_len = len(COLORS[color])
-                break
+                    found_colors += color
+                append_len = len(color)
 
         if append_len == 0:
             # Current string does not start with any escape sequence, so,

--- a/ydiff.py
+++ b/ydiff.py
@@ -129,7 +129,7 @@ def strsplit(text, width):
         if text[0] == "\x1b":
             color_end = text.find("m")
             if color_end != -1:
-                color = text[:color_end+1]
+                color = text[:color_end + 1]
                 if color == COLORS["reset"]:
                     found_colors = ""
                 else:


### PR DESCRIPTION
Hi @ymattw, thanks for writing ydiff, I find it to be very useful and I see you've become active again.

I have a rather substantially modified fork of it, and managed to identify and optimize a very hot loop. This is an adaptation of https://github.com/joshuarli/ydiff/commit/e6c4a3e5f87923a791b3da52c57af8468f123b99.

In practice I've found roughly a 2x speedup: https://github.com/joshuarli/ydiff#Performance

Granted, the speedup is only really noticeable if you're rendering extremely large diffs.
