### PR TITLE
`setup.py`: Fix `python_requires` for ydiff >=1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
     ],
-    python_requires='>=3',
+    python_requires='>=3.3',  # see sys.hexversion check in ydiff.py
     py_modules=['ydiff'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Python 3.3 is required since 1c724af9e5ba9aaa97d7c72e29e3d88455e0364c.