### PR TITLE
[codex] Handle pager broken pipe cleanup

### DIFF
--- a/tests/test_ydiff.py
+++ b/tests/test_ydiff.py
@@ -799,6 +799,41 @@ class MainUnitTests(unittest.TestCase):
             # markup called twice
             self.assertEqual(ydiff.DiffMarker.markup.call_count, 2)
 
+    @mock.patch('ydiff.DiffMarker.markup',
+                side_effect=lambda _: iter(['line']))
+    @mock.patch('subprocess.Popen')
+    def test_markup_to_pager_broken_pipe_cleanup(self, m_popen, m_markup):
+        class BrokenPipeStdin:
+            def __init__(self):
+                self.closed = False
+
+            def write(self, data):
+                raise BrokenPipeError
+
+            def close(self):
+                self.closed = True
+                raise BrokenPipeError
+
+        diff = mock.Mock()
+        stdin = BrokenPipeStdin()
+        pager = mock.Mock(stdin=stdin)
+        m_popen.return_value = pager
+
+        with mock.patch('ydiff.DiffParser.parse', return_value=iter([diff])):
+            opts = mock.Mock()
+            opts.pager = 'less'
+            opts.pager_options = None
+            opts.side_by_side = True
+            opts.width = 80
+            opts.tab_width = 8
+            opts.wrap = False
+            opts.theme = 'default'
+
+            ydiff.markup_to_pager(b'', opts)
+
+        self.assertTrue(stdin.closed)
+        pager.wait.assert_called_once_with()
+
     def test_get_patch_stream_stdin_file(self):
         with mock.patch('os.fstat') as m_fstat:
             m_fstat.return_value.st_mode = 33188  # S_IFREG

--- a/ydiff.py
+++ b/ydiff.py
@@ -609,27 +609,33 @@ def markup_to_pager(stream, opts):
     pager = subprocess.Popen(
         pager_cmd, stdin=subprocess.PIPE, stdout=sys.stdout)
 
-    marker = DiffMarker(side_by_side=opts.side_by_side, width=opts.width,
-                        tab_width=opts.tab_width, wrap=opts.wrap,
-                        theme=opts.theme)
-    term_width = _terminal_width()
-    diffs = DiffParser(stream).parse()
-    # Fetch one diff first, output a separation line for the rest, if any.
     try:
-        diff = next(diffs)
-        for line in marker.markup(diff):
-            pager.stdin.write(line.encode('utf-8'))
-    except StopIteration:
+        marker = DiffMarker(side_by_side=opts.side_by_side, width=opts.width,
+                            tab_width=opts.tab_width, wrap=opts.wrap,
+                            theme=opts.theme)
+        term_width = _terminal_width()
+        diffs = DiffParser(stream).parse()
+        # Fetch one diff first, output a separation line for the rest, if any.
+        try:
+            diff = next(diffs)
+            for line in marker.markup(diff):
+                pager.stdin.write(line.encode('utf-8'))
+        except StopIteration:
+            pass
+        for diff in diffs:
+            separator = _colorize('─' * (term_width - 1) + '\n',
+                                  'file_separator', theme=opts.theme)
+            pager.stdin.write(separator.encode('utf-8'))
+            for line in marker.markup(diff):
+                pager.stdin.write(line.encode('utf-8'))
+    except BrokenPipeError:
         pass
-    for diff in diffs:
-        separator = _colorize('─' * (term_width - 1) + '\n', 'file_separator',
-                              theme=opts.theme)
-        pager.stdin.write(separator.encode('utf-8'))
-        for line in marker.markup(diff):
-            pager.stdin.write(line.encode('utf-8'))
-
-    pager.stdin.close()
-    pager.wait()
+    finally:
+        try:
+            pager.stdin.close()
+        except BrokenPipeError:
+            pass
+        pager.wait()
 
 
 # Keys for revision control probe, diff and log (optional) with diff


### PR DESCRIPTION
## Summary

- Handle early pager exits inside `markup_to_pager()`.
- Explicitly close pager stdin and wait for the pager process, ignoring broken pipes during cleanup.
- Add a unit test for pager stdin raising `BrokenPipeError` on write and close.

## Root cause

When `less` exits early, for example by pressing `q` before it consumes the full diff, `ydiff` can hit `BrokenPipeError` while writing to the pager. The outer wrapper catches that exception, but the pager stdin buffer was left for Python finalization, which can print an ignored `BrokenPipeError`.

## Validation

- `python3 -m unittest tests.test_ydiff`
- `PATH=/tmp/ydiff-check-venv/bin:$PATH make test`
- Manual check in `~/echo`: run patched `ydiff.py`, press `q`, confirm no finalizer warning.
